### PR TITLE
fix(MemoryViz): restore the red peak line + Download peak allocs button

### DIFF
--- a/MemoryViz.js
+++ b/MemoryViz.js
@@ -905,6 +905,24 @@ function MemoryPlot(
     .attr('stroke-width', d => typeof d.elem === 'string' && d.elem.startsWith('pool:') ? 3 : null)
     .attr('vector-effect', d => typeof d.elem === 'string' && d.elem.startsWith('pool:') ? 'non-scaling-stroke' : null);
 
+  // Restored from main: red dashed vertical line marking the timestep where
+  // active memory peaked. Uses the peak_timestep field that PR #4 brought
+  // back to process_alloc_data's return value.
+  if (data.peak_timestep != null && data.max_at_time.length > 0) {
+    scrub_group
+      .append('line')
+      .attr('class', 'peak-memory-line')
+      .attr('x1', xscale(data.peak_timestep))
+      .attr('y1', 0)
+      .attr('x2', xscale(data.peak_timestep))
+      .attr('y2', plot_height)
+      .attr('stroke', 'red')
+      .attr('stroke-width', 2)
+      .attr('vector-effect', 'non-scaling-stroke')
+      .attr('stroke-dasharray', '6,3')
+      .attr('pointer-events', 'none');
+  }
+
   const axis = plot_coordinate_space.append('g').call(yaxis);
 
   function handleZoom(event) {
@@ -1137,6 +1155,29 @@ function create_trace_view(
   d.append('label').text(
     `Detail: ${max_entries} of ${data.elements_length} entries`,
   );
+
+  // Restored from main: download the blocks active at peak memory as JSON.
+  // Uses peak_alloc_events restored to process_alloc_data's return value.
+  if (Array.isArray(data.peak_alloc_events) && data.peak_alloc_events.length > 0) {
+    d.append('button')
+      .attr('class', 'peak-alloc-download')
+      .attr('style', 'margin-left: 10px')
+      .text(`Download peak allocs JSON (${data.peak_alloc_events.length} blocks)`)
+      .on('click', () => {
+        const json = JSON.stringify(
+          data.peak_alloc_events,
+          (_k, v) => (typeof v === 'bigint' ? v.toString() : v),
+          2,
+        );
+        const blob = new Blob([json], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'peak_alloc_events.json';
+        a.click();
+        URL.revokeObjectURL(url);
+      });
+  }
 
   d.append('span').text('  |  ');
   const search_input = d.append('input')

--- a/tests/REPORT.md
+++ b/tests/REPORT.md
@@ -1,10 +1,14 @@
-# Restoring `peak_timestep` / `peak_alloc_events` in `process_alloc_data`
+# Restoring main's "find max" feature on top of PR #3
 
 > Companion to PR #3 (`cUZpARuPDATE`). The PR description says:
 >
 > > *"for the viz js i want both func in the main branch and the cUZpARuPDATE — cuz in the main branch have a func is to find max i would like to keep that"*
 >
-> This branch keeps **both** sides: PR #3's modular `process_alloc_data.js` (with `isPrivatePoolId`, the new `include_private_inactive` arg, the `segment_pool_id` parameter, etc.) **and** main's "find max" logic that PR #3 dropped (`peak_timestep`, `peak_alloc_events`, the wall-clock peak log).
+> This branch keeps **both** sides: PR #3's modular `process_alloc_data.js` (with `isPrivatePoolId`, the new `include_private_inactive` arg, the `segment_pool_id` parameter, etc.) **and** main's "find max" feature that PR #3 dropped — which actually has **three** layers (revision after first review):
+>
+> 1. **Data**: `process_alloc_data` returns `peak_timestep` + `peak_alloc_events`
+> 2. **Visualization**: `MemoryPlot` draws a **red dashed vertical line** at the peak timestep
+> 3. **UI**: `create_trace_view` shows a **"Download peak allocs JSON"** button next to the detail slider
 
 ## What main had that PR #3 dropped
 
@@ -28,14 +32,21 @@ These aren't cosmetic — `MemoryPlot` (in `MemoryViz.js`) draws a red dashed "p
 
 ## What this branch restores (without removing PR #3 features)
 
-Diff scope: **`process_alloc_data.js` only**, +62 / −2.
+Diff scope: **`process_alloc_data.js` (+62/−2) + `MemoryViz.js` (+41/−0)**.
+
+### `process_alloc_data.js`
 
 1. **`let peak_elem = null;`** declared next to `let max_size = 0;`.
 2. The two `max_size = Math.max(...)` updates **inside the action loop** become explicit if-blocks that also set `peak_elem = elem` when the new total exceeds the running max. (The third `max_size` update sits in the post-loop segment-events `while`, where there is no `elem` in scope; that one is left as `Math.max(...)` and `peak_elem` keeps the last meaningful action's value, matching `main`'s semantics.)
 3. After the data has been built, compute `peak_timestep` by scanning `max_at_time`, log the peak time line (with date if `time_us` is present, "no timestamp available" otherwise), then derive `peak_alloc_events` by filtering `data` for entries whose `timesteps` straddle the peak.
 4. Add `peak_timestep` and `peak_alloc_events` to the return object — exactly the shape `MemoryViz.js` consumers expect from `main`.
 
-Nothing in `MemoryViz.js` is touched. PR #3's other improvements stay intact:
+### `MemoryViz.js`
+
+5. **Red dashed peak line in `MemoryPlot`** — after the polygon block in `MemoryPlot`, append a `<line>` at `xscale(data.peak_timestep)` with `stroke=red`, `stroke-dasharray=6,3`, `stroke-width=2`, `vector-effect=non-scaling-stroke` (so it stays 2px under zoom), `pointer-events=none` (doesn't intercept hovers). Tagged `class="peak-memory-line"` for the integration test to find. Guarded by `data.peak_timestep != null && data.max_at_time.length > 0` so it no-ops if peak data is missing.
+6. **"Download peak allocs JSON" button in `create_trace_view`** — placed right after the `Detail: N of M entries` label. Same JSON-blob + `<a download>` pattern as `main`. Tagged `class="peak-alloc-download"`. Guarded by `Array.isArray(data.peak_alloc_events) && data.peak_alloc_events.length > 0` so old/empty snapshots don't get an empty-download button.
+
+Nothing else in `MemoryViz.js` is touched. PR #3's other improvements stay intact:
 
 - `process_alloc_data.js` is still the modular, dependency-free file (no d3/DOM imports).
 - `isPrivatePoolId`, the `include_private_inactive = false` parameter, the pool envelope tracking, the new `segment_pool_id` param on `Segment`, and the ghost-block context line are all preserved.
@@ -78,6 +89,8 @@ node tests/run.mjs
 | unit | console contains `"Blocks at peak memory"` | Restored log |
 | **integration** | Page can `import { add_local_files } from "../MemoryViz.js"` and load the real pickle through MemoryViz's auto-created file input | End-to-end smoke test that the merged code still parses real snapshots |
 | integration | Same two console logs fire after upload | Restored behaviour reaches users |
+| integration | A `<line class="peak-memory-line">` element exists with `stroke="red"` and `stroke-dasharray="6,3"` after the snapshot loads | The red dashed peak line is actually drawn |
+| integration | A `<button class="peak-alloc-download">` exists whose text matches `Download peak allocs JSON` | The download UI is actually present |
 
 ### Live result on this snapshot
 
@@ -90,12 +103,16 @@ node tests/run.mjs
                    "allocations_over_time","max_at_time","summarized_mem",
                    "elements_length","context_for_id"]}
   peak logs:
-    Peak active memory: 207.7MiB (217763364 bytes) at 2026-04-28T08:43:50.760Z (2026/4/28 下午4:43:50)
+    Peak active memory: 207.7MiB (217763364 bytes) at 2026-04-28T08:43:50.760Z (...)
     Blocks at peak memory (red dashed line): 15
 
-✓ integration (add_local_files end-to-end)
+✓ integration (add_local_files end-to-end + UI)
+  dom:    {"peak_line_found":true,"peak_line_stroke":"red","peak_line_dash":"6,3",
+           "peak_line_x1":"864.5625",
+           "download_button_found":true,
+           "download_button_text":"Download peak allocs JSON (15 blocks)"}
   peak logs:
-    Peak active memory: 207.7MiB (217763364 bytes) at 2026-04-28T08:43:50.760Z (2026/4/28 下午4:43:50)
+    Peak active memory: 207.7MiB (217763364 bytes) at 2026-04-28T08:43:50.760Z (...)
     Blocks at peak memory (red dashed line): 15
 
 ========== PASS ==========

--- a/tests/run.mjs
+++ b/tests/run.mjs
@@ -114,7 +114,20 @@ async function runIntegrationTest(browser, baseUrl) {
   if (!hasPeakLog) failures.push("missing 'Peak active memory:' console.log");
   const hasBlocksLog = result.console_logs.some(l => l.includes("Blocks at peak memory"));
   if (!hasBlocksLog) failures.push("missing 'Blocks at peak memory' console.log");
-  return { name: "integration (add_local_files end-to-end)", result, failures };
+
+  // PR #4 also restored two pieces of UI from main: the red dashed peak line
+  // in MemoryPlot, and the "Download peak allocs JSON" button in
+  // create_trace_view. Assert both DOM elements actually rendered.
+  const dom = result.dom || {};
+  if (!dom.peak_line_found) failures.push("missing red dashed peak line (.peak-memory-line) in MemoryPlot");
+  if (dom.peak_line_found && dom.peak_line_stroke !== "red") failures.push("peak line stroke is not 'red'");
+  if (dom.peak_line_found && dom.peak_line_dash !== "6,3") failures.push("peak line is not dashed (stroke-dasharray='6,3')");
+  if (!dom.download_button_found) failures.push("missing 'Download peak allocs JSON' button (button.peak-alloc-download)");
+  if (dom.download_button_found && !/Download peak allocs JSON/.test(dom.download_button_text || "")) {
+    failures.push("download button text is wrong: " + JSON.stringify(dom.download_button_text));
+  }
+
+  return { name: "integration (add_local_files end-to-end + UI)", result, failures };
 }
 
 async function main() {
@@ -144,6 +157,9 @@ async function main() {
     console.log(`\n${ok ? "✓" : "✗"} ${r.name}`);
     if (r.result?.result) {
       console.log("  result:", JSON.stringify(r.result.result));
+    }
+    if (r.result?.dom) {
+      console.log("  dom:   ", JSON.stringify(r.result.dom));
     }
     const peakLog = (r.result?.console_logs || []).filter(l =>
       l.includes("Peak active memory:") || l.includes("Blocks at peak memory"),

--- a/tests/test_integration.html
+++ b/tests/test_integration.html
@@ -64,8 +64,23 @@
       const ret = origPush(...items);
       for (const item of items) {
         if (typeof item === "string" && item.includes("Peak active memory:")) {
-          window.__test.status = "done";
-          document.getElementById("status").textContent = "done — peak log received";
+          // Peak log fired → renderer should now have placed the red dashed
+          // line + the download button. Snapshot the DOM so the runner can
+          // assert without re-querying through Puppeteer.
+          requestAnimationFrame(() => {
+            const peakLine = document.querySelector(".peak-memory-line");
+            const dlButton = document.querySelector("button.peak-alloc-download");
+            window.__test.dom = {
+              peak_line_found: !!peakLine,
+              peak_line_stroke: peakLine?.getAttribute("stroke") ?? null,
+              peak_line_dash: peakLine?.getAttribute("stroke-dasharray") ?? null,
+              peak_line_x1: peakLine?.getAttribute("x1") ?? null,
+              download_button_found: !!dlButton,
+              download_button_text: dlButton?.textContent ?? null,
+            };
+            window.__test.status = "done";
+            document.getElementById("status").textContent = "done — peak log received";
+          });
         }
       }
       return ret;


### PR DESCRIPTION
Round-2 of the cUZpARuPDATE-vs-main reconciliation. PR #4 restored the **data** (`peak_timestep`, `peak_alloc_events`) but the two **UI consumers** in `MemoryViz.js` were still missing — so even though the numbers were right, "find max" was invisible to the user. As you flagged after the merge:

> 1. u did not give back the "red line" function of max mem usage aka i did not see the red line
> 2. u did not restore the down load json of max bton from the main branch

This PR ports both. **`process_alloc_data.js` is unchanged.**

## Patches in `MemoryViz.js` (+41/-0)

1. **Red dashed peak line in `MemoryPlot`** — after the polygon block, append `<line class="peak-memory-line" stroke="red" stroke-dasharray="6,3" stroke-width="2" vector-effect="non-scaling-stroke" pointer-events="none">` at `xscale(data.peak_timestep)`. Guarded by `data.peak_timestep != null && data.max_at_time.length > 0` so old/empty snapshots no-op.
2. **"Download peak allocs JSON (N blocks)" button in `create_trace_view`** — placed right after the `Detail: N of M entries` label. Same Blob + `<a download="peak_alloc_events.json">` pattern as `main`. Guarded by `Array.isArray(data.peak_alloc_events) && length > 0`.

Both elements use stable class names so the integration test can assert them.

## Test harness extended (`tests/test_integration.html` + `tests/run.mjs`)

The integration test now also reads back the rendered DOM after the snapshot loads and asserts:

- `<line.peak-memory-line>` exists with `stroke="red"` and `stroke-dasharray="6,3"`
- `<button.peak-alloc-download>` exists with text matching `Download peak allocs JSON`

Live result on `gpu_memory_snapshot-adam.pickle`:

```
✓ unit (process_alloc_data direct)
  result: {"max_size":217763364,"peak_timestep":29,"peak_alloc_events_count":15,
           "max_at_time_length":32,"elements_length":18,"has_context_for_id":true,
           "keys":["max_size","peak_timestep","peak_alloc_events",
                   "allocations_over_time","max_at_time","summarized_mem",
                   "elements_length","context_for_id"]}
  peak logs:
    Peak active memory: 207.7MiB (217763364 bytes) at 2026-04-28T08:43:50.760Z (...)
    Blocks at peak memory (red dashed line): 15

✓ integration (add_local_files end-to-end + UI)
  dom: {"peak_line_found":true,"peak_line_stroke":"red","peak_line_dash":"6,3",
        "peak_line_x1":"864.5625",
        "download_button_found":true,
        "download_button_text":"Download peak allocs JSON (15 blocks)"}
========== PASS ==========
```

The integration test would have failed before this commit (`peak_line_found:false`, `download_button_found:false`) — that's exactly the regression that slipped through round-1.

## Test plan

- [ ] `npm install && node tests/run.mjs` reports PASS
- [ ] Open the snapshot in a browser (gh-pages or local `python3 -m http.server`); confirm the **red dashed vertical line** is visible at `peak_timestep` in the `MemoryPlot` SVG.
- [ ] Click **"Download peak allocs JSON (15 blocks)"** next to the Detail slider; confirm a `peak_alloc_events.json` file downloads with 15 entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)